### PR TITLE
Show user name as title when user is in a meeting

### DIFF
--- a/public/js/office.web.js
+++ b/public/js/office.web.js
@@ -49,6 +49,8 @@ $(() => {
   function userInMeetDecorator(user, userView) {
     const userInMeet = user.inMeet === true;
 
+    if (userInMeet) { userView.attr("title", user.name); }
+
     userView.toggleClass("user-in-call", userInMeet);
     userView.toggleClass("user-not-in-call", !userInMeet);
   }
@@ -151,7 +153,7 @@ $(() => {
 
     if (loggedUserRoomId === roomId && loggedUserId !== user.id) {
       const roomTitle = getRoomName(roomId);
-      notify(`${user.name} entered into the room ${roomTitle}`, options);   
+      notify(`${user.name} entered into the room ${roomTitle}`, options);
     }
   }
 
@@ -221,7 +223,7 @@ $(() => {
         officeEvents.enterInRoom(roomId);
         startVideoConference(roomId, getRoomName(roomId),officeEvents);
       }
-    }, 300);  
+    }, 300);
   }
 
   function initEnterRoomButton(officeEvents){


### PR DESCRIPTION
### Description

Fix #132

This PR main intent is to enable title with the user name to be shown when the user is in the meeting.

More details of how to reproduce could be found in issue #132.