### PR TITLE
fix get menu using webpack

### DIFF
--- a/frontend/office.js
+++ b/frontend/office.js
@@ -51,7 +51,7 @@ $(() => {
   }
 
   function initGetUserMenu(officeEvents) {
-    $("[user-presence]").initialize(function() {
+    $.initialize("[user-presence]",function() {
       $(this).contextMenu({
         menuSelector: "#getUserMenu",
         menuSelected: function(invokedOn) {
@@ -255,7 +255,7 @@ $(() => {
       icon: user.imageUrl
     };
 
-    text = `${user.name} is calling you to join in ${getRoomName(roomId)}`;
+    const text = `${user.name} is calling you to join in ${getRoomName(roomId)}`;
     notify(text, options);
     setTimeout(() => {
       const isConfirmed = confirm(text);


### PR DESCRIPTION
### Description
This PR fixes the get menu

### How to test?
Execute right click on the user avatar.

### Expected behavior
should appear the "get menu"
![image](https://user-images.githubusercontent.com/643779/57345894-f719ca00-7122-11e9-998b-314b5eaa6eeb.png)

