### PR TITLE
Prevent meet conflict

### DIFF
--- a/app.server.js
+++ b/app.server.js
@@ -48,7 +48,7 @@ app.get("/office", (req, res) => {
       //try to prevent diferente use hostname to identify unique meet: 
       //obviously localhost is not coveraged here
       roomsData.forEach(room => {
-        room.id = req.hostname+"-"+room.id;
+        room.id = `${req.hostname}-${room.id}`;
       });
 
       console.log(roomsData);

--- a/app.server.js
+++ b/app.server.js
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 8080;
 const HOST = "0.0.0.0";
 const GOOGLE_CREDENTIAL =
   process.env.GOOGLE_CREDENTIAL ||
-  "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com"; 
+  "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com";
 const app = express();
 
 // favicon

--- a/app.server.js
+++ b/app.server.js
@@ -11,8 +11,7 @@ const PORT = process.env.PORT || 8080;
 const HOST = "0.0.0.0";
 const GOOGLE_CREDENTIAL =
   process.env.GOOGLE_CREDENTIAL ||
-  "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com";
-const PRODUCTION_PROTOCOL = process.env.PRODUCTION_PROTOCOL || "http";  
+  "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com"; 
 const app = express();
 
 // favicon
@@ -37,19 +36,6 @@ app.use(
 // FIX ME: here we have to get the google APIkey in another way.
 app.locals.googleCredential = new GoogleCredentialController(GOOGLE_CREDENTIAL);
 
-// FIX ME: follow the correct production protocol
-app.use((req, res, next) => {
-  var proto = req.connection.encrypted ? 'https' : 'http';
-  // only do this if you trust the proxy
-  proto = req.headers['x-forwarded-proto'] || proto;
-
-  if (proto !== PRODUCTION_PROTOCOL){
-      res.redirect(`${PRODUCTION_PROTOCOL}://${req.header('host')}${req.url}`)
-  }else{
-    next()
-  }
-})
-
 // routes
 app.get("/", (req, res) => {
   res.render("index");
@@ -58,6 +44,13 @@ app.get("/", (req, res) => {
 app.get("/office", (req, res) => {
   fetchRooms(ROOMS_SOURCE)
     .then(roomsData => {
+
+      //try to prevent diferente use hostname to identify unique meet: 
+      //obviously localhost is not coveraged here
+      roomsData.forEach(room => {
+        room.id = req.hostname+"-"+room.id;
+      });
+
       console.log(roomsData);
 
       app.locals.roomsDetail = roomsData;

--- a/app.server.js
+++ b/app.server.js
@@ -12,6 +12,7 @@ const HOST = "0.0.0.0";
 const GOOGLE_CREDENTIAL =
   process.env.GOOGLE_CREDENTIAL ||
   "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com";
+const PRODUCTION_PROTOCOL = process.env.PRODUCTION_PROTOCOL || "http";  
 const app = express();
 
 // favicon
@@ -35,6 +36,19 @@ app.use(
 
 // FIX ME: here we have to get the google APIkey in another way.
 app.locals.googleCredential = new GoogleCredentialController(GOOGLE_CREDENTIAL);
+
+// FIX ME: follow the correct production protocol
+app.use((req, res, next) => {
+  var proto = req.connection.encrypted ? 'https' : 'http';
+  // only do this if you trust the proxy
+  proto = req.headers['x-forwarded-proto'] || proto;
+
+  if (proto !== PRODUCTION_PROTOCOL){
+      res.redirect(`${PRODUCTION_PROTOCOL}://${req.header('host')}${req.url}`)
+  }else{
+    next()
+  }
+})
 
 // routes
 app.get("/", (req, res) => {

--- a/views/office.ejs
+++ b/views/office.ejs
@@ -44,7 +44,7 @@
             </div>
           </div>
           <div class="card-footer text-muted room-footer ">
-            <a id="room_btn_enter-<%= roomsDetail[i].id %>" href="#<%= roomsDetail[i].id%>" class="card-link btn-enter-in-room float-left" external-meet-url="<%=   [i].externalMeetUrl%>" enter-room room-name="<%= roomsDetail[i].name%>" room-disable-meeting="<%= roomsDetail[i].disableMeeting %>" room-id="<%= roomsDetail[i].id%>" >Enter this room</a>
+            <a id="room_btn_enter-<%= roomsDetail[i].id %>" href="#<%= roomsDetail[i].id%>" class="card-link btn-enter-in-room float-left" external-meet-url="<%=[i].externalMeetUrl%>" enter-room room-name="<%= roomsDetail[i].name%>" room-disable-meeting="<%= roomsDetail[i].disableMeeting %>" room-id="<%= roomsDetail[i].id%>" >Enter this room</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description
This PR concatenate the hostname + room-id to prevent room id conflict with other environments. We have two environments when the room-id is "room-1" when they enter in the Jitisi meet they will enter in the same meet.   

### How to test? 
Create two environments using the default room-id

### Expected behavior
Expected that room-id is concatenated with domain name:
http://maydomain.com/office#**mydomain.com**-ac2b235a-b1e2-4848-a687-6669a3f7551b 
