### PR TITLE
revert the md5 strategy and concat host only on vedeo meet

### DIFF
--- a/app.server.js
+++ b/app.server.js
@@ -5,7 +5,6 @@ import GoogleCredentialController from "./controllers/google.credentials.control
 import OfficeController from "./controllers/office.controller";
 import fetchRooms from "./controllers/rooms.controller";
 import Office from "./office.server";
-import crypto from "crypto"
 
 
 const ROOMS_SOURCE = process.env.ROOMS_SOURCE;
@@ -46,12 +45,6 @@ app.get("/", (req, res) => {
 app.get("/office", (req, res) => {
   fetchRooms(ROOMS_SOURCE)
     .then(roomsData => {
-
-      //try to prevent diferente use hostname to identify unique meet: 
-      //obviously localhost is not coveraged here
-      roomsData.forEach(room => {
-        room.id = crypto.createHash('md5').update(`${req.hostname}-${room.id}`).digest("hex");
-      });
 
       console.log(roomsData);
 

--- a/frontend/office.js
+++ b/frontend/office.js
@@ -112,7 +112,7 @@ $(() => {
 
   function getMeetingOptions(roomId) {
     return {
-      roomName: roomId,
+      roomName: `${roomId}-${window.location.hostname}`,
       width: "100%",
       height: "100%",
       parentNode: document.querySelector("#meet"),


### PR DESCRIPTION
##Description
This PR concatenate the hostname + room-id to prevent room id conflict with other environments. We have two environments when the room-id is "room-1" when they enter in the Jitisi meet they will enter in the same meet.

##How to test?
Create two environments using the default room-id

##Expected behavior
when you enter in meet the jitsi meet id needs to be **room-id + domain**