### PR TITLE
fix redirect http when we have a reverse proxy

### DIFF
--- a/app.server.js
+++ b/app.server.js
@@ -41,7 +41,9 @@ app.locals.googleCredential = new GoogleCredentialController(GOOGLE_CREDENTIAL);
 
 app.use((req, res, next) => {
 
-  if (ENFORCE_SSL==='true' && !req.secure){
+  let isSecure = req.secure || req.headers['x-forwared-proto'] === 'https';
+
+  if (ENFORCE_SSL==='true' && !isSecure){
       res.redirect(`https://${req.hostname}${req.url}`)
   }else{
     next()


### PR DESCRIPTION
Description
When the client is in production with HTTPS and access the matrix in HTTP the users receive google login error. This PR enables to define the Environment Variable with the correct production protocol

How to test?
Folow the this steps: #142

Expected behavior
If the environment variable is defined https and the user access http we will redirect him to https