### PR TITLE
Assets cache invalidation

### DIFF
--- a/backend/app.server.js
+++ b/backend/app.server.js
@@ -4,9 +4,11 @@ import GoogleCredentialController from "./controllers/google.credentials.control
 import OfficeController from "./controllers/office.controller";
 import fetchRooms from "./controllers/rooms.controller";
 import Office from "./office.server";
+import assets from './controllers/assets.controller.js'
 
 
 const ROOMS_SOURCE = process.env.ROOMS_SOURCE;
+const ENVIRONMENT = process.env.NODE_ENV
 const PORT = process.env.PORT || 8080;
 const HOST = "0.0.0.0";
 const GOOGLE_CREDENTIAL =
@@ -31,6 +33,13 @@ staticFiles.forEach((source) =>
 
 // FIX ME: here we have to get the google APIkey in another way.
 app.locals.googleCredential = new GoogleCredentialController(GOOGLE_CREDENTIAL);
+
+const assetsManifestFile = path.join(__dirname, '..', 'public', 'dist', 'manifest.json')
+const assetsManifestResolver = ENVIRONMENT === 'production' ? 
+  assets.staticManifestResolver(assetsManifestFile) :
+  assets.lazyManifestResolver(assetsManifestFile)
+
+app.locals.assets = assets.createAssetsResolver(assetsManifestResolver, '/dist')
 
 app.use((req, res, next) => {
 

--- a/backend/controllers/assets.controller.js
+++ b/backend/controllers/assets.controller.js
@@ -1,0 +1,33 @@
+import fs from 'fs'
+
+const staticManifestResolver = (manifestFile) => {
+  const manifestData = fs.readFileSync(manifestFile);
+  const manifest = JSON.parse(manifestData);
+
+  return () => manifest
+}
+
+const lazyManifestResolver = (manifestPath) => {
+  return () =>  {
+    const resolver = staticManifestResolver(manifestPath)
+    return resolver() 
+  }
+}
+
+
+const createAssetsResolver = (manifestResolver, assetsBasePath) => {
+  const getAssetUrl = (assetName) => {
+    const manifest = manifestResolver()
+    const asset = manifest[assetName] || assetName
+
+    return `${assetsBasePath}/${asset}`
+  }
+
+  return {
+    url: getAssetUrl,
+  }
+}
+
+
+export default { staticManifestResolver, lazyManifestResolver, createAssetsResolver }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3507,6 +3507,17 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -4887,6 +4898,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -7819,6 +7839,12 @@
         "crypto-random-string": "^1.0.0"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -8126,6 +8152,17 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "webpack-manifest-plugin": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
+      "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "lodash": ">=3.5 <5",
+        "tapable": "^1.0.0"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start-frontend-development-server": "webpack --watch --config webpack.development.js",
     "build-backend": "babel ./backend -d dist",
     "build-frontend": "webpack --mode production --config webpack.production.js",
-    "start-backend": "node ./dist/app.server.js",
+    "start-backend": "NODE_ENV=production node ./dist/app.server.js",
     "start": "npm-run-all -p start-backend-development-server start-frontend-development-server",
     "test": "nyc --reporter=text mocha --require @babel/register './test/**/*.test.js' --exit",
     "cover": "nyc report --reporter=html --reporter=text --reporter=lcovonly --report-dir=test/coverage;",
@@ -49,6 +49,7 @@
     "supertest": "^4.0.2",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1",
+    "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "^4.2.1"
   }
 }

--- a/test/app.server.test.js
+++ b/test/app.server.test.js
@@ -38,12 +38,12 @@ describe("Unit testing the / route", () => {
         );
       }));
 
-  it("should there is login-bundle.js on rendering", () =>
+  it("should there is login.js on rendering", () =>
     request(app)
       .get("/")
       .then(response => {
-        expect(response.text).to.contain(
-          '<script src="dist/login-bundle.js"></script>'
+        expect(response.text).to.match(
+          /<script src="\/dist\/login-.[a-z0-9]+\.js"><\/script>/
         );
       }));
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -31,6 +31,6 @@
     </div>
   </div>
   <script src="https://apis.google.com/js/platform.js" async defer></script>
-  <script src="dist/login-bundle.js"></script>
+  <script src="<%= assets.url('login.js') %>"></script>
 </body>
 </html>

--- a/views/office.ejs
+++ b/views/office.ejs
@@ -59,6 +59,6 @@
   </div>
   <script src='https://meet.jit.si/external_api.js'></script>
   <script src="https://apis.google.com/js/platform.js" async defer></script>
-  <script src="dist/office-bundle.js"></script>
+  <script src="<%= assets.url('office.js') %>"></script>
 </body>
 </html>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const webpack = require("webpack");
+const ManifestPlugin = require('webpack-manifest-plugin');
 const sourcePath = path.join(__dirname, "frontend");
 const buildPath = path.join(__dirname, "public", "dist");
 
@@ -12,10 +13,11 @@ module.exports = {
     new webpack.ProvidePlugin({
       $: "jquery",
       jQuery: "jquery"
-    })
+    }),
+    new ManifestPlugin()
   ],
   output: {
     path: buildPath,
-    filename: "[name]-bundle.js"
+    filename: "[name]-[contenthash].js"
   }
 };


### PR DESCRIPTION
### Problem
Browser can cache assets and users may not receive updates.

## Solution
- Bundle assets with content hash at file name. (https://webpack.js.org/guides/caching/);
- Generate a manifest file for bundled assets;
- Use manifest to resolve assets name;

In development mode, the manifest file is read always, while in production mode, the manifest is read once.