### PR TITLE
add hability to customize css

### DIFF
--- a/backend/app.server.js
+++ b/backend/app.server.js
@@ -14,8 +14,11 @@ const GOOGLE_CREDENTIAL =
   process.env.GOOGLE_CREDENTIAL ||
   "990846956506-bfhbjsu4nl5mvlkngr3tsmfcek24e8t8.apps.googleusercontent.com";
 const ENFORCE_SSL = process.env.ENFORCE_SSL || "false";
+const CUSTOM_STYLE = process.env.CUSTOM_STYLE || "";
 
 const app = express();
+
+app.locals.CUSTOM_STYLE = CUSTOM_STYLE
 
 // set the template engine ejs
 app.set("view engine", "ejs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -3911,7 +3911,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3929,11 +3930,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3946,15 +3949,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4057,7 +4063,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4067,6 +4074,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4079,17 +4087,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4106,6 +4117,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4178,7 +4190,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4188,6 +4201,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4263,7 +4277,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4293,6 +4308,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4310,6 +4326,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4348,11 +4365,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/views/office.ejs
+++ b/views/office.ejs
@@ -5,6 +5,9 @@
   <link href='https://fonts.googleapis.com/css?family=Lato' rel='stylesheet'>
   <link rel="stylesheet" href="<%= assets.url('office.css') %>">
   <%- include('favicons'); %>
+  <style type="text/css">
+    <%- CUSTOM_STYLE %>  
+  </style>>
 </head>
 <body>
   <%- include('header'); %>


### PR DESCRIPTION
### Description
Provide the ability to set a custom CSS with the environment variable  
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->

### How to test?
Set environment variable `CUSTOM_STYLE` with a custom CSS like `body{background-image: url('https://image.freepik.com/vetores-gratis/festa-junina-bandeiras-decoracao-fundo_1017-18260.jpg');}`

### Expected behavior
Custom CSS will be applied and in the example case the background will appear festa junina 
