### PR TITLE
Redirect new room to mortheus

### DIFF
--- a/backend/app/app.routes.js
+++ b/backend/app/app.routes.js
@@ -22,7 +22,7 @@ router.get("/new", (req, res) => {
     req.app.locals.roomsDetail.splice(1, 0, newRoom);
   }
 
-  res.redirect(`/office#${req.query.roomId}`);
+  res.redirect(`/morpheus/room/${req.query.roomId}`);
 });
 
 router.get("/remove", (req, res) => {

--- a/frontend/src/office.js
+++ b/frontend/src/office.js
@@ -286,12 +286,14 @@ $(() => {
     enterRoom.on("click", (e) => {
       const roomId = $(e.target).attr("room-id");
       const disableMeeting = new Boolean(
-        $(e.target).attr("room-disable-meeting"),
+        $(e.target).attr("room-disable-meeting")=="true",
       );
+
+      console.log($(e.target).attr("room-disable-meeting"));  
 
       officeEvents.enterInRoom(roomId);
       matrixProfile.storeRoom(roomId);
-
+      console.log("disableMeeting:",disableMeeting);
       if (disableMeeting == true) return;
 
       startVideoConference(roomId, getRoomName(roomId), officeEvents);

--- a/frontend/src/office.js
+++ b/frontend/src/office.js
@@ -289,11 +289,9 @@ $(() => {
         $(e.target).attr("room-disable-meeting")=="true",
       );
 
-      console.log($(e.target).attr("room-disable-meeting"));  
-
       officeEvents.enterInRoom(roomId);
       matrixProfile.storeRoom(roomId);
-      console.log("disableMeeting:",disableMeeting);
+
       if (disableMeeting == true) return;
 
       startVideoConference(roomId, getRoomName(roomId), officeEvents);


### PR DESCRIPTION
### Problem
when you create a room with the route http://localhost:8080/new?roomId=xxxxxx&roomName=aaaaa and you are using the legacy theme, when you would try to enter in meeting in this new room, nothing happen.

### My Solution
1. I changed the redirect from legacy theme to the new Morpheus room meeting theme
2. I fixed in the legacy theme for entering in meeting in the new rooms 

### How to test?
create a new room with this route: http://localhost:8080/new?roomId=xxxxxx&roomName=aaaaa 

### Expected behavior

- [x] you need to be redirected to the new room in Morpheus theme. 

- [x] in the legacy theme: when you click in the button "enter in meeting" the meeting modal have to start your meeting 
