### PR TITLE
add support to open external meeting in morpheus layout

### DIFF
--- a/frontend/src/morpheus/containers/OfficePage.js
+++ b/frontend/src/morpheus/containers/OfficePage.js
@@ -54,6 +54,8 @@ const OfficePage = ({
               history.replace(`/morpheus/office/${room.id}`);
             }}
             onEnterMeeting={() => {
+              emitEnterInRoom(room.id);
+              onSetCurrentRoom(room);
               console.log(room.externalMeetUrl);
               if(room.externalMeetUrl){
                var externalMeetRoom = window.open(room.externalMeetUrl);

--- a/frontend/src/morpheus/containers/OfficePage.js
+++ b/frontend/src/morpheus/containers/OfficePage.js
@@ -54,7 +54,27 @@ const OfficePage = ({
               history.replace(`/morpheus/office/${room.id}`);
             }}
             onEnterMeeting={() => {
-              history.push(`/morpheus/room/${room.id}`);
+              console.log(room.externalMeetUrl);
+              if(room.externalMeetUrl){
+               var externalMeetRoom = window.open(room.externalMeetUrl);
+
+                var externalMeetRoomMonitoring = function(){
+                  window.setTimeout(function() {
+                    console.log(externalMeetRoom.closed);
+                    if (externalMeetRoom.closed) {
+                      console.log('The external meeting has been closed');
+                    }else{
+                      externalMeetRoomMonitoring();
+                    }
+                    
+                    }, 1000);
+                }
+
+                externalMeetRoomMonitoring();
+
+              }else{
+                history.push(`/morpheus/room/${room.id}`);
+              }
             }}
           />
         ))}

--- a/frontend/src/morpheus/store/reducers.js
+++ b/frontend/src/morpheus/store/reducers.js
@@ -62,6 +62,7 @@ const buildOfficeState = state => {
   let office = rooms.map(room => ({
     id: room.id,
     name: room.name,
+    externalMeetUrl: room.externalMeetUrl,
     users: usersInRoom.filter(u => u.room === room.id).map(u => u.user)
   }));
 

--- a/frontend/test/morpheus/store/reducers.test.js
+++ b/frontend/test/morpheus/store/reducers.test.js
@@ -16,25 +16,27 @@ describe("morpheus/store/reducers", () => {
     const stateAfter = {
       ...initialState,
       rooms: [
-        { id: 1, name: "room 1" },
-        { id: 2, name: "room 2" }
+        { id: 1, name: "room 1",externalMeetUrl:"http://externalMeetUrl-1" },
+        { id: 2, name: "room 2",externalMeetUrl:"http://externalMeetUrl-2"}
       ],
       office: [
         {
           id: 1,
           name: "room 1",
+          externalMeetUrl:"http://externalMeetUrl-1",
           users: []
         },
         {
           id: 2,
           name: "room 2",
+          externalMeetUrl:"http://externalMeetUrl-2",
           users: []
         }
       ]
     };
     const action = addRooms([
-      { id: 1, name: "room 1" },
-      { id: 2, name: "room 2" }
+      { id: 1, name: "room 1", externalMeetUrl:"http://externalMeetUrl-1"},
+      { id: 2, name: "room 2", externalMeetUrl:"http://externalMeetUrl-2"}
     ]);
 
     deepFreeze(stateBefore);
@@ -99,8 +101,8 @@ describe("morpheus/store/reducers", () => {
     const stateBefore = {
       ...initialState,
       rooms: [
-        { id: "1", name: "room 1", users: [] },
-        { id: "2", name: "room 2", users: [] }
+        { id: "1", name: "room 1", externalMeetUrl:"http://externalMeetUrl-1", users: [] },
+        { id: "2", name: "room 2", externalMeetUrl:"http://externalMeetUrl-2", users: [] }
       ]
     };
     const stateAfter = {
@@ -109,11 +111,13 @@ describe("morpheus/store/reducers", () => {
         {
           id: "1",
           name: "room 1",
+          externalMeetUrl:"http://externalMeetUrl-1",
           users: []
         },
         {
           id: "2",
           name: "room 2",
+          externalMeetUrl:"http://externalMeetUrl-2",
           users: []
         }
       ],
@@ -136,6 +140,7 @@ describe("morpheus/store/reducers", () => {
         {
           id: "1",
           name: "room 1",
+          externalMeetUrl:"http://externalMeetUrl-1",
           users: [
             {
               id: 100,
@@ -147,6 +152,7 @@ describe("morpheus/store/reducers", () => {
         {
           id: "2",
           name: "room 2",
+          externalMeetUrl:"http://externalMeetUrl-2",
           users: [
             {
               id: 200,


### PR DESCRIPTION
### Description
We have been problems with Jitsi. And we are trying to test the experience of using an external meeting provider.  

### How to test?
add **externalMeetUrl** attribute with a Unique meet URL of your preferred meeting provider.

```
{ 
      "id":"dc668138-37ee-4c6a-9d26-2d646c4d70ea",
      "name":"Zion 2",
      "externalMeetUrl":"https://myexternalmeetprovideruniqueurl"
}
```

### Expected behavior
when you click in "Enter Meet" #matrix will open the external meet in a tab.
