### PR TITLE
Open external meet needs to show headphone decorator

### DIFF
--- a/frontend/src/morpheus/containers/OfficePage.js
+++ b/frontend/src/morpheus/containers/OfficePage.js
@@ -10,7 +10,7 @@ import {
   selectCurrentRoom,
   selectRooms
 } from "../store/selectors";
-import { emitEnterInRoom } from "../socket";
+import { emitEnterInRoom, emitStartMeeting, emitLeftMeeting} from "../socket";
 import { setCurrentRoom } from "../store/actions";
 import { CurrentRoomPropType } from "../store/models";
 
@@ -58,13 +58,15 @@ const OfficePage = ({
               onSetCurrentRoom(room);
               console.log(room.externalMeetUrl);
               if(room.externalMeetUrl){
-               var externalMeetRoom = window.open(room.externalMeetUrl);
+                emitStartMeeting();   
+                var externalMeetRoom = window.open(room.externalMeetUrl);
 
                 var externalMeetRoomMonitoring = function(){
                   window.setTimeout(function() {
                     console.log(externalMeetRoom.closed);
                     if (externalMeetRoom.closed) {
                       console.log('The external meeting has been closed');
+                      emitLeftMeeting();
                     }else{
                       externalMeetRoomMonitoring();
                     }


### PR DESCRIPTION
### Description
The implementation of the external meet is not showing the Headphones decorator when the user enter in the meet.  

### How to test?
Create a room with *externalMeetUrl* param and enter in meet of this room

### Expected behavior
the user avatar needs to show headphones
