### PR TITLE
Add externalMeetUrl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,23 @@ The **#matrix** project has some environments that important to define.
 		   },
 		   {
 		      "id":"${UUID}",
-		      "name":"Data Services"
+		      "name":"Data Services",
+			  "externalMeetUrl": "https://external-url-room/key-room"
 		   }
 		 ]
+
+### External Meet
+The default video conferencing in meetings is [Jitsi](https://jitsi.org/jitsi-meet/), but you can change that in any room, using [Meet](https://meet.google.com/) or [Zoom](https://zoom.us/). For that, you just need provide the parameter `externalMeetUrl` in your room config:
+```
+ROOMS_DATA=[
+		   {
+		      "id":"${UUID}",
+		      "name":"Meeting External",
+			  "externalMeetUrl": "https://external-url-room/key-room"
+		   }
+		 ]
+		 ```
+
 
 
 ## Contributing


### PR DESCRIPTION
# Description
In this PR we put more information about `externalMeetUrl` parameter, to help people to use other video conferences providers

# How to test?
Verify if the English needs to be fixed and if all images are appearing

# Expected behavior
An understandable README.md for all people.