### PR TITLE
Add healthcheck

### DIFF
--- a/backend/app/app.healthcheck.js
+++ b/backend/app/app.healthcheck.js
@@ -1,0 +1,16 @@
+import { createTerminus } from "@godaddy/terminus";
+
+function onHealthCheck() {
+    // checks if the system is healthy,
+    // we can add the checks here as needed
+    return Promise.resolve();
+}
+
+module.exports = (server) => {
+  createTerminus(server, {
+    healthChecks: {
+      '/healthz': onHealthCheck,
+      verbatim: true
+    }
+  });
+};

--- a/backend/app/index.js
+++ b/backend/app/index.js
@@ -1,11 +1,13 @@
 import app from "./app.server";
 import officeFactory from "./office.factory";
+import healthCheck from "./app.healthcheck";
 import { HOST, PORT } from "./app.config";
 
 const server = app.listen(PORT, HOST, undefined, () => {
   console.log(`Running on http://${HOST}:${PORT}`);
 });
 
+healthCheck(server);
 officeFactory(server).start();
 
 module.exports = server;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -912,6 +912,15 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@godaddy/terminus": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.3.1.tgz",
+			"integrity": "sha512-zChILIprb4nWTGJ/pXafbGZqJA7yB6JzFQp5f8PBR5B0cJ6f9Nd40ySLFTBzko+PEZgVaJlKrJi5gUQLTI9dpw==",
+			"requires": {
+				"es6-promisify": "^6.0.0",
+				"stoppable": "^1.0.5"
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -1914,6 +1923,11 @@
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
 			"dev": true
 		},
+		"es6-promisify": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.0.tgz",
+			"integrity": "sha512-jCsk2fpfEFusVv1MDkF4Uf0hAzIKNDMgR6LyOIw6a3jwkN1sCgWzuwgnsHY9YSQ8n8P31HoncvE0LC44cpWTrw=="
+		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2271,8 +2285,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2290,13 +2303,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2309,18 +2320,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2423,8 +2431,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2434,7 +2441,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2447,20 +2453,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2477,7 +2480,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2550,8 +2552,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2561,7 +2562,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2637,8 +2637,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2668,7 +2667,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2686,7 +2684,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2725,13 +2722,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -5072,6 +5067,11 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
 		},
 		"string-width": {
 			"version": "2.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "cover": "nyc report --reporter=html --reporter=text --reporter=lcovonly --report-dir=test/coverage;"
   },
   "dependencies": {
+    "@godaddy/terminus": "^4.3.1",
     "ejs": "^2.6.2",
     "express": "^4.17.1",
     "hashmap": "^2.3.0",

--- a/backend/test/app.healthcheck.test.js
+++ b/backend/test/app.healthcheck.test.js
@@ -1,0 +1,22 @@
+const request = require("supertest");
+const healthCheck = require("../app/app.healthcheck");
+const app = require("../app/app.server");
+
+describe("Unit testing the /healthz route", () => {
+  let server;
+  beforeEach(function () {
+    server = app.listen();
+  });
+  afterEach(function () {
+    server.close();
+  });
+
+  it("should return OK status", (done) => {
+    healthCheck(server);
+    request(server)
+      .get("/healthz")
+      .expect(200, {
+        status: 'ok'
+      }, done);
+  });
+});


### PR DESCRIPTION
### Description

Add a new endpoint to be used for health check. I used terminus because it provide a lot of util stuffs like graceful shutdown (it'll be important when we work on high availability for matrix)

### How to test?

Make the following curl:
```console
➜  Charts (camais-rooms) ✔ curl -i http://localhost:8080/healthz
HTTP/1.1 200 OK
Content-Type: application/json
Date: Tue, 17 Mar 2020 17:41:08 GMT
Connection: keep-alive
Content-Length: 15

{"status":"ok"}
```
or accessing via browser:

![Captura de Tela 2020-03-17 às 14 41 40](https://user-images.githubusercontent.com/4973742/76885062-6f7e0b00-685d-11ea-8fcf-8dec85db04bf.png)

### Expected behavior

Have an endpoint to use as healthcheck. It's important to have to check liveness and readiness in Kubernetes, or a load balancer status check, for example.
