### PR TITLE
fix error start project with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,5 @@ services:
     working_dir: /var/app
     ports:
      - '8080:8080'
-    volumes:
-      - .:/var/app
-    # entrypoint: 'sh /docker-entrypoint.sh npm run start'
     build:
       context: ./


### PR DESCRIPTION
### Description
Was not possible run project using docker-compose up immediately after clone project.

### How to test?
After clone project, execute the below command:
```
docker-compose up
```

### Expected behavior
Start the project.
