### PR TITLE
Env var docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+*.env
 
 # next.js build output
 .next

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3'
 services:
   web:
     working_dir: /var/app
+    env_file:
+      - variables.env
     ports:
-     - '8080:8080'
+     - '8080:8080'    
+    # entrypoint: 'sh /docker-entrypoint.sh npm run start'
     build:
       context: ./


### PR DESCRIPTION
### Description
- Adding example file env vars to docker-compose.
- For security, ignoring any .env at gitignore.

### How to test?
Just add any .env file and check that will be ignored to commit.

### Expected behavior
After add file variables.env to root of project will be possible add env vars easily to start the project, like GOOGLE_CREDENTIAL and ROOMS env variables.

Example variables.env
```
GOOGLE_CREDENTIAL=XXXXXX.googleusercontent.com
#ENFORCE_SSL=false
ROOMS_SOURCE=ENVIRONMENT
ROOMS_DATA=[{"id":"17755865-e0a6-4809-b389-eeff5590fd3d","name":"ValarDohaeris"},{"id":"490693fb-1751-498a-a23a-3785e677530c","name":"Osiris"},{"id":"da5eef6b-9e0c-4c32-81eb-17596114bf5b","name":"Icarus"},{"id":"e8ed1b89-afa9-469f-8108-e527b51c76a1","name":"Caduceus"},{"id":"bab0452c-bbfa-4365-b263-6aa9d26d8e33","name":"Brahma"},{"id":"706e8018-8e4e-40a2-a433-97535db6cc54","name":"Novalis"},{"id":"59008e8f-a961-4ad2-a2e4-b31b3e398a50","name":"Vigilant"},{"id":"2acbea57-64ba-4c55-9d20-042843c6e225","name":"Zion"}]
```
