### PR TITLE
Fix jitsi logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The embeded meet is provided by [meet.jit.si](https://meet.jit.si) service and t
 at [8x8](https://8x8.com). Access the [jitsi GitHub](https://github.com/jitsi/jitsi-meet#security) and learn more about this amazing video bridge service.     
 
 
-
 |                                Meeting Room                                |                                          With Sidebar                                           |
 | :------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
 | <img src="docs/img/matrix-meet-room.png" title="Office page" width="100%"> | <img src="docs/img/matrix-meet-room-sidebar.png" title="Office page with Sidebar" width="100%"> |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The inside of **#matrix** there are some rooms. In this rooms is possible to see
 
 You can only enter in a room to show for the other that you are available there through the `ENTER ROOM` button or enter in a meeting through the button `ENTER MEETING`. 
 
+The embeded meet is provided by [meet.jit.si](https://meet.jit.si) service and this service is maintained by the [Jitsi team](https://jitsi.org/the-community/#meet-our-team)
+at [8x8](https://8x8.com). Access the [jitsi GitHub](https://github.com/jitsi/jitsi-meet#security) and learn more about this amazing video bridge service.     
+
+
+
 |                                Meeting Room                                |                                          With Sidebar                                           |
 | :------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
 | <img src="docs/img/matrix-meet-room.png" title="Office page" width="100%"> | <img src="docs/img/matrix-meet-room-sidebar.png" title="Office page with Sidebar" width="100%"> |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ If you want run the **#matrix**, you need follow steps:
 		GOOGLE_CLIENT_ID=000000000-xxxxxxxxxx.apps.googleusercontent.com
 		GOOGLE_SECRET=gXXXXXXXXXXXXss
 		GOOGLE_CALLBACK_URL=http://localhost:8080/auth/google/callback
-		COOKIE_SESSION_SECRET:matrix-session
-		COOKIE_SESSION_MAX_AGE:2592000000
+		COOKIE_SESSION_SECRET=matrix-session
+		COOKIE_SESSION_MAX_AGE=2592000000
 		ENFORCE_SSL=false
 		WHITELIST_DOMAINS=[]
 

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "description": "Matrix produces a virtual office for remote teams. In this project, you can run a virtual office to simulate the physical environment",
   "repository": "https://github.com/ResultadosDigitais/matrix",
   "keywords": ["online workspace", "virtual office", "remote teams"],
+  "stack": "container",
   "env": {
     "GOOGLE_CLIENT_ID": {
       "description": "Google Client Id to the OAuth authentication",

--- a/app.json
+++ b/app.json
@@ -3,7 +3,6 @@
   "description": "Matrix produces a virtual office for remote teams. In this project, you can run a virtual office to simulate the physical environment",
   "repository": "https://github.com/ResultadosDigitais/matrix",
   "keywords": ["online workspace", "virtual office", "remote teams"],
-  "stack": "container", 
   "env": {
     "GOOGLE_CLIENT_ID": {
       "description": "Google Client Id to the OAuth authentication",

--- a/frontend/src/jitsi/JitsiConfig.js
+++ b/frontend/src/jitsi/JitsiConfig.js
@@ -22,11 +22,6 @@ export const adaptJitsiConfig = (roomId, parentNode, meetingSettings) => {
         // Enables experimental simulcast support on Firefox.
         enableFirefoxSimulcast: meetingSettings.enableFirefoxSimulcast
       }
-    },
-    interfaceConfigOverwrite: {
-      SHOW_JITSI_WATERMARK: true,
-      SHOW_WATERMARK_FOR_GUESTS: true,
-      SHOW_BRAND_WATERMARK: true
     }
   };
 

--- a/frontend/src/jitsi/JitsiConfig.js
+++ b/frontend/src/jitsi/JitsiConfig.js
@@ -24,9 +24,9 @@ export const adaptJitsiConfig = (roomId, parentNode, meetingSettings) => {
       }
     },
     interfaceConfigOverwrite: {
-      SHOW_JITSI_WATERMARK: false,
-      SHOW_WATERMARK_FOR_GUESTS: false,
-      SHOW_BRAND_WATERMARK: false
+      SHOW_JITSI_WATERMARK: true,
+      SHOW_WATERMARK_FOR_GUESTS: true,
+      SHOW_BRAND_WATERMARK: true
     }
   };
 


### PR DESCRIPTION
### Description
In the jitsi.org documentation, they explain to not hide jitsi.org logo when you are running embedded jitsi. We made a mistake hide the logo and this PR fix. @jitsi forgive us for the hesitation.  

![image](https://user-images.githubusercontent.com/643779/77124114-c253f000-6a20-11ea-9979-51f7416e9899.png)


### How to test?
Enter in a meeting 

### Expected behavior
The jitsi.org logo has to be present. 

![image](https://user-images.githubusercontent.com/643779/77124221-0a731280-6a21-11ea-9ec1-ddcef3c42494.png)
