### PR TITLE
fix headset on/off

### DIFF
--- a/frontend/src/morpheus/hooks/useEvents.js
+++ b/frontend/src/morpheus/hooks/useEvents.js
@@ -49,9 +49,11 @@ const useEvents = (
         }
       });
       events.onParticipantStartedMeet((user, roomId) => {
+        user.inMeet = true;
         onUserEnterMeeting(user, roomId);
       });
       events.onParticipantLeftMeet((user, roomId) => {
+        user.inMeet = false;
         onUserLeftMeeting(user, roomId);
       });
       events.onDisconnect(userId => {


### PR DESCRIPTION
### Description
Fix for bug #234 - Headset used to mark if person is in meeting is not visible outside the meeting 

### How to test?
1. Open two browsers with two users to test
2. Join a meeting in a browser
3. See your profile photo with headset inside the meeting (it is ok)
4. See your profile photo with headset at second browser. 

### Implementation
I could fix it but the code is not easy to understand.

I don't know if I'm fixing it in the better point of the code. But I know here we have an event handle for join / left the meet.
```
      events.onParticipantStartedMeet((user, roomId) => {
        user.inMeet = true;
        onUserEnterMeeting(user, roomId);
      });
      events.onParticipantLeftMeet((user, roomId) => {
        user.inMeet = false;
        onUserLeftMeeting(user, roomId);
      });
```

Possible point of bug: there is no documentation or comments explain the methods. So I don't know what onDisconnect meaning. Is it detecting an user that disconnecting closing the browser? If so, should I `user.inMeet = false` before disconnect? I tested and could not reproduce a problem of have a user always with headset due a disconnect. But I don't know the right behavior.

```
      events.onDisconnect(userId => {
        onRemoveUser(userId);
      });
```