### PR TITLE
Ajusta a notificação para navegadores que não possui suporte

### DIFF
--- a/frontend/src/components/NotificationCheckbox.js
+++ b/frontend/src/components/NotificationCheckbox.js
@@ -11,12 +11,21 @@ import NotificationImportant from "@material-ui/icons/NotificationImportant";
 import {
   isNotificationEnabled,
   isNotificationBlocked,
+  browserHasSupport,
   requestPermissionToNotify
 } from "../notification";
 import { showMessageDialog } from "../morpheus/store/actions";
 
 const NotificationCheckbox = ({ onChange, openMessageDialog, isDisabled }) => {
   const [isAllowed, toggleAllowed] = useState(isNotificationEnabled());
+
+  if (!browserHasSupport()) {
+    return (
+      <Tooltip title="This browser doesn't support notifications">
+        <NotificationsOff />
+      </Tooltip>
+    );
+  }
 
   if (!isAllowed) {
     return (

--- a/frontend/src/notification.js
+++ b/frontend/src/notification.js
@@ -1,8 +1,15 @@
 const NOTIFICATION_PERMISSION_GRANTED = "granted";
 const NOTIFICATION_PERMISSION_DENIED = "denied";
 
-export const isNotificationEnabled = () =>
-  Notification.permission === NOTIFICATION_PERMISSION_GRANTED;
+export const browserHasSupport = () => !!Notification;
+
+export const isNotificationEnabled = () => {
+  if (!browserHasSupport()) {
+    return false;
+  }
+
+  return Notification.permission === NOTIFICATION_PERMISSION_GRANTED;
+}
 
 export const isNotificationBlocked = () =>
   Notification.permission === NOTIFICATION_PERMISSION_DENIED;
@@ -14,5 +21,7 @@ export const requestPermissionToNotify = callback => {
 };
 
 export const showBrowserNotification = message => {
-  new Notification(message);
+  if (isNotificationEnabled()) {
+    new Notification(message);
+  }
 };


### PR DESCRIPTION
### Description

@tchiarato reportou o seguinte erro no iOS:

![Image from iOS](https://user-images.githubusercontent.com/673904/77343665-d0e82300-6d10-11ea-9cec-5db17df33654.jpg)

Olhando a documentação do Notification no MDN vi que o Safari no iOS não tem suporte: https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API#Browser_compatibility

### How to test?

- [ ] Testar a notificação em um navegador que possui suporte, como o Chrome ou Firefox, e verificar se continua funcionando.
- [ ] Testar no iOS se a página não quebra e o ícone notifica a falta do suporte:

![notification-not-supported](https://user-images.githubusercontent.com/673904/77344196-92069d00-6d11-11ea-81fa-79fba4491893.png)


