### PR TITLE
remove GCP exclusive button branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If you want run the **#matrix**, you need [docker-compose](https://docs.docker.c
 
 If you prefer, you can run **#matrix** on GCP:
 
-<a href="https://deploy.cloud.run?git_repo=https://github.com/ResultadosDigitais/matrix&revision=gcp-deploy-button">
+<a href="https://deploy.cloud.run?git_repo=https://github.com/ResultadosDigitais/matrix">
 <img alt="Run on Google Cloud" src="https://deploy.cloud.run/button.svg" style="max-width:200px"  />
 </a>
 


### PR DESCRIPTION
### Description
When we created the **Google Cloud Run Button** There was an incompatibility between `app.json` for Heroku and GCP. 

We reported this problem to google in [this issue](https://github.com/GoogleCloudPlatform/cloud-run-button/issues/112) and they fixed ignoring the `stack` field in [this commit](https://github.com/GoogleCloudPlatform/cloud-run-button/commit/1c284503067b12b0186d3a5d1fbc462494cd3f80) 

### How to test?
Execute installation with **Google 8Cloud Run Button**  

### Expected behavior
everything needs to work well and [this](https://github.com/GoogleCloudPlatform/cloud-run-button/issues/112#issuecomment-602226502) problem have to be fixed.
