### PR TITLE
Add ROOMS_DATA and ROOMS_SOURCE at variables.env.example

### DIFF
--- a/variables.example.env
+++ b/variables.example.env
@@ -5,3 +5,5 @@ COOKIE_SESSION_SECRET=matrix-session
 COOKIE_SESSION_MAX_AGE=2592000000
 ENFORCE_SSL=false
 WHITELIST_DOMAINS="[]"
+ROOMS_SOURCE=ENVIRONMENT
+ROOMS_DATA=[{"id":"{UUID_A}","name":"Lounge","disableMeeting":true},{"id":"{UUID_B}","name":"WAR ROOM CDP"},{"id":"{UUID_C}","name":"Data Services","externalMeetUrl":"https://external-url-room/key-room"}]


### PR DESCRIPTION
Added missing `variables` at `variables.example.env`. Without that, docker-compose does not runs matrix 😢 .