### PR TITLE
Add a user list method of authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ If you will run in production we strongly recommend you close your environment u
 
 		WHITELIST_DOMAINS=["@domain1.com","@domain2.com"]
 
+If you can't use a VPN or don't have a custom domain for your users, and you still want to restrict access to the **#matrix**, you can define a `WHITELIST_USERS` variable to create an array of trusted e-mails that can access your virtual office.
+
+		WHITELIST_USERS=["teste@domain.com","teste2@domain.com"]
+
 ## Versions
 
 | Version | Name | Description | Docs |

--- a/backend/app/app.config.js
+++ b/backend/app/app.config.js
@@ -52,6 +52,13 @@ export function getAllowedDomains() {
   return allowedDomains;
 }
 
+export function getAllowedUsers() {
+  const allowedUsers =
+    environment.parseVariable(process.env.WHITELIST_USERS) || [];
+
+  return allowedUsers;
+}
+
 export function getServerConfig() {
   const host = "0.0.0.0"
   const port = process.env.PORT || 8080

--- a/backend/app/services/auth/authorization.js
+++ b/backend/app/services/auth/authorization.js
@@ -15,3 +15,19 @@ export function domainAuthorization(allowedDomains) {
     return allowedDomainsSet.has(domain);
   };
 }
+
+export function userAuthorization(allowedUsers) {
+  const allowedUsersSet = new Set(allowedUsers);
+
+  return ({ email }) => {
+    if (allowedUsersSet.size === 0) {
+      return true;
+    }
+
+    if (email === undefined) {
+      return false
+    }
+
+    return allowedUsersSet.has(email);
+  };
+}

--- a/backend/app/services/auth/authorization.test.js
+++ b/backend/app/services/auth/authorization.test.js
@@ -38,10 +38,10 @@ describe(".domainAuthorization()", () => {
   });
 });
 describe(".userAuthorization()", () => {
-  describe("when user list is empty", () => {
+  describe("when user whitelist is empty or not set", () => {
     const isAuthorized = userAuthorization([]);
 
-    it("should return true with an email", () => {
+    it("should return true with any email", () => {
       expect(isAuthorized({ email: "teste@teste.com" })).toBeTruthy();
     });
 
@@ -57,20 +57,25 @@ describe(".userAuthorization()", () => {
   describe("when user list has values", () => {
     const isAuthorized = userAuthorization(["teste@gmail.com"]);
 
-    it("should return true when email is listed", () => {
+    it("should return true when the correct email is listed", () => {
       expect(isAuthorized({ email: "teste@gmail.com" })).toBeTruthy();
     });
 
-    it("should return false when email isn't listed", () => {
+    it("should return false when email isn't in the list", () => {
       expect(isAuthorized({ email: "teste2@gmail.com" })).toBeFalsy();
     });
 
-    it("should return false when email is empty string", () => {
+    it("should return false when email is an empty string", () => {
       expect(isAuthorized({ email: "" })).toBeFalsy();
     });
 
     it("should return false when email is undefined", () => {
       expect(isAuthorized({ email: undefined })).toBeFalsy();
     });
+
+    it("should return false when email is poorly formatted", () => {
+      expect(isAuthorized({ email: " teste@gmail.com " })).toBeFalsy();
+    });
+
   });
 });

--- a/backend/app/services/auth/authorization.test.js
+++ b/backend/app/services/auth/authorization.test.js
@@ -37,3 +37,40 @@ describe(".domainAuthorization()", () => {
     });
   });
 });
+describe(".userAuthorization()", () => {
+  describe("when user list is empty", () => {
+    const isAuthorized = userAuthorization([]);
+
+    it("should return true with email", () => {
+      expect(isAuthorized({ email: "teste@teste.com" })).toBeTruthy();
+    });
+
+    it("should return true without email", () => {
+      expect(isAuthorized({ email: undefined })).toBeTruthy();
+    });
+
+    it("should return true with empty email", () => {
+      expect(isAuthorized({ email: "" })).toBeTruthy();
+    });
+  });
+
+  describe("when user list has values", () => {
+    const isAuthorized = userAuthorization(["teste@gmail.com"]);
+
+    it("should return true when email is listed", () => {
+      expect(isAuthorized({ email: "teste@gmail.com" })).toBeTruthy();
+    });
+
+    it("should return false when email isn't listed", () => {
+      expect(isAuthorized({ email: "teste2@gmail.com" })).toBeFalsy();
+    });
+
+    it("should return false when email is empty string", () => {
+      expect(isAuthorized({ email: "" })).toBeFalsy();
+    });
+
+    it("should return false when email is undefined", () => {
+      expect(isAuthorized({ email: undefined })).toBeFalsy();
+    });
+  });
+});

--- a/backend/app/services/auth/authorization.test.js
+++ b/backend/app/services/auth/authorization.test.js
@@ -1,4 +1,4 @@
-import { domainAuthorization } from "./authorization";
+import { domainAuthorization, userAuthorization } from "./authorization";
 
 describe(".domainAuthorization()", () => {
   describe("when allowed list is empty", () => {
@@ -41,15 +41,15 @@ describe(".userAuthorization()", () => {
   describe("when user list is empty", () => {
     const isAuthorized = userAuthorization([]);
 
-    it("should return true with email", () => {
+    it("should return true with an email", () => {
       expect(isAuthorized({ email: "teste@teste.com" })).toBeTruthy();
     });
 
-    it("should return true without email", () => {
+    it("should return true with an undefined email", () => {
       expect(isAuthorized({ email: undefined })).toBeTruthy();
     });
 
-    it("should return true with empty email", () => {
+    it("should return true with an empty email", () => {
       expect(isAuthorized({ email: "" })).toBeTruthy();
     });
   });

--- a/backend/app/services/auth/index.js
+++ b/backend/app/services/auth/index.js
@@ -1,12 +1,14 @@
 import passport from "passport";
 
-import { getAuthConfig, getAllowedDomains } from "../../app.config";
+import { getAuthConfig, getAllowedDomains, getAllowedUsers } from "../../app.config";
 
-import { domainAuthorization } from "./authorization";
+import { domainAuthorization, userAuthorization } from "./authorization";
 import { buildAuthStrategy } from "./strategy";
 
 const authConfig = getAuthConfig();
-const isAuthorized = domainAuthorization(getAllowedDomains());
+var isAuthorized = domainAuthorization(getAllowedDomains());
+
+isAuthorized = userAuthorization(getAllowedUsers());
 
 passport.use(buildAuthStrategy(authConfig, isAuthorized));
 passport.serializeUser((user, done) => done(null, user));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added a new form of user authorization: WHITELIST_USERS.
 
 ### Removed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1]
+## [2.0.1] 2020-05-05
 ### Added
 - New `ctrl+click` to open a embeded Jitsi Meet in a new Tab.
 - Now we are using `jest`for backend tests


### PR DESCRIPTION
### Description

Considering the use case where a deploy can only be accessed by members of a project, however the use of a secure domain is not possible. This PR adds an authorization method where only a list of users can login. Still maintaining authentication with Google Auth.

### How to test?
Add the WHITELIST_USERS Env variable with an array of e-mails (WHITELIST_USERS=["teste@gmail.com", "teste2@gmail.com"]). Try to login with a google account.

### Expected behavior
If the user have their email listed, login. If not, log that him is not authorized.
