### PR TITLE
Add a cache layer to npm install and run tests

### DIFF
--- a/docker-images/matrix-dev/Dockerfile
+++ b/docker-images/matrix-dev/Dockerfile
@@ -1,11 +1,27 @@
-FROM node:10.15.3-alpine
+FROM node:10.16.0-alpine
 
-RUN mkdir -p /var/app
 WORKDIR /var/app
+
+# Cache npm install
+COPY package.json /var/app/package.json
+RUN npm install --ignore-scripts
+
+# Copy the docker entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-COPY . /var/app
+# Copy the application's files
+COPY . .
+
+# Install application
+RUN npm run bootstrap
+RUN npm run build-backend
+RUN npm run build-frontend
+
+# Run tests
+RUN npm run test:ci
+RUN npm run cover
 
 EXPOSE 8080
+
 ENTRYPOINT ["sh","/docker-entrypoint.sh"]
-CMD ["npm" , "run", "start-server"]
+CMD ["npm" ,  "--prefix", "backend/", "run", "start-backend"]


### PR DESCRIPTION
### Description
To facilitate the development and testing of new features, I restructured the DEV Dockerfile. With this, the download of dependencies will be cached (as long as the package.json file is not changed) and at the end, the tests are executed.

### How to test?
Copy the content of the Dockerfile (docker-images\matrix-dev) to the root Dockerfile.

### Expected behavior
After change something in the sourcecode, the build process will skip the "npm install --ignore-scripts" layer.

### Considerations
This procedure increases the final size and layer numbers of the image. As much as the increase is not impressive, it is important not to use this Dockerfile in production.
