### PR TITLE
Add room description option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-
+- new room description option
 ### Removed
 
 ### Changed

--- a/frontend/src/components/AppBarTitle.js
+++ b/frontend/src/components/AppBarTitle.js
@@ -5,7 +5,9 @@ import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles(() => ({
   title: {
-    flexGrow: 1
+    flexGrow: 1,
+    display: "flex",
+    alignItems: "center",
   }
 }));
 

--- a/frontend/src/components/RoomCard.js
+++ b/frontend/src/components/RoomCard.js
@@ -4,6 +4,7 @@ import Card from "@material-ui/core/Card";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
+import InfoIcon from "@material-ui/icons/InfoOutlined";
 import Avatar from "@material-ui/core/Avatar";
 import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
@@ -15,6 +16,13 @@ const useStyles = makeStyles(() => ({
   root: {
     display: "flex",
     flexDirection: "column"
+  },
+  flex: {
+    display: "flex",
+  },
+  descriptionIcon: {
+    marginLeft: "auto",
+    flex: "0 0 auto",
   },
   contentAction: {
     flex: 1,
@@ -49,7 +57,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const RoomCard = ({ name, users, meetingEnabled, onEnterRoom, onEnterMeeting }) => {
+const RoomCard = ({ name, description, users, meetingEnabled, onEnterRoom, onEnterMeeting }) => {
   const [isExpanded, toggleExpand] = useState(false);
   const classes = useStyles();
   const userToShow = isExpanded ? users : users.slice(0, 3);
@@ -64,9 +72,16 @@ const RoomCard = ({ name, users, meetingEnabled, onEnterRoom, onEnterMeeting }) 
         }}
       >
         <CardContent className={classes.content}>
-          <Typography gutterBottom variant="h5" component="h2">
-            {name}
-          </Typography>
+          <div className={classes.flex}>
+            <Typography gutterBottom variant="h5" component="h2" className={classes.content}>
+              {name}
+            </Typography>
+            {description && (
+              <Tooltip title={description}>
+                <InfoIcon className={classes.descriptionIcon} color="action" />
+              </Tooltip>
+            )}
+          </div>
           <div className={classes.userGrid}>
             {userToShow.map(user => (
               <Tooltip key={user.id} title={user.name}>
@@ -107,7 +122,8 @@ RoomCard.propTypes = {
   onEnterMeeting: PropTypes.func,
   meetingEnabled: PropTypes.bool,
   users: PropTypes.arrayOf(PropTypes.object),
-  name: PropTypes.string
+  name: PropTypes.string,
+  description: PropTypes.string,
 };
 
 RoomCard.defaultProps = {
@@ -115,7 +131,8 @@ RoomCard.defaultProps = {
   onEnterMeeting: () => {},
   meetingEnabled: true,
   users: [],
-  name: ""
+  name: "",
+  description: null,
 };
 
 export default RoomCard;

--- a/frontend/src/morpheus/containers/OfficePage.js
+++ b/frontend/src/morpheus/containers/OfficePage.js
@@ -40,7 +40,6 @@ const OfficePage = ({
       }
     }
   }, [match.params.roomId]);
-
   return (
     <div className={classes.root}>
       <Grid>
@@ -58,7 +57,7 @@ const OfficePage = ({
               onSetCurrentRoom(room);
 
               if(room.externalMeetUrl){
-                emitStartMeeting();   
+                emitStartMeeting();
                 const externalMeetRoom = window.open(room.externalMeetUrl);
 
                 const externalMeetRoomMonitoring = () => {
@@ -67,7 +66,7 @@ const OfficePage = ({
                       emitLeftMeeting();
                     }else{
                       externalMeetRoomMonitoring();
-                    } 
+                    }
                   }, 1000);
                 }
 

--- a/frontend/src/morpheus/containers/RoomAppBar.js
+++ b/frontend/src/morpheus/containers/RoomAppBar.js
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-
+import { makeStyles } from "@material-ui/core/styles";
+import InfoIcon from "@material-ui/icons/InfoOutlined";
+import Tooltip from "@material-ui/core/Tooltip";
 import AppBarTitle from "../../components/AppBarTitle";
 import MenuRoom from "../../components/MenuRoom";
 import ShareModal from "../../components/ShareModal";
@@ -9,6 +11,12 @@ import { selectRooms, selectSystemSettings } from "../store/selectors";
 import { emitLeftMeeting } from "../socket";
 import { changeSystemSetting, toggleTheme } from "../store/actions";
 import { RoomsPropType, SettingsPropType } from "../store/models";
+
+const useStyles = makeStyles(() => ({
+  descriptionIcon: {
+    marginLeft: 16,
+  },
+}));
 
 const RoomAppBar = ({
   onChangeSettings,
@@ -22,10 +30,18 @@ const RoomAppBar = ({
   const { roomId } = match.params;
   const findRoomResult = rooms.find(r => r.id === roomId);
   const currentRoomName = findRoomResult ? findRoomResult.name : "";
-
+  const currentRoomDescription = findRoomResult ? findRoomResult.description : "";
+  const classes = useStyles();
   return (
     <>
-      <AppBarTitle>{currentRoomName}</AppBarTitle>
+      <AppBarTitle>
+        {currentRoomName}
+        {currentRoomDescription && (
+          <Tooltip title={currentRoomDescription}>
+            <InfoIcon color="action" fontSize="small" className={classes.descriptionIcon} />
+          </Tooltip>
+        )}
+      </AppBarTitle>
       <MenuRoom
         onExitRoom={() => {
           emitLeftMeeting();

--- a/frontend/src/morpheus/store/reducers.js
+++ b/frontend/src/morpheus/store/reducers.js
@@ -62,6 +62,7 @@ const buildOfficeState = state => {
   let office = rooms.map(room => ({
     id: room.id,
     name: room.name,
+    description: room.description,
     meetingEnabled: !room.disableMeeting,
     externalMeetUrl: room.externalMeetUrl,
     users: usersInRoom.filter(u => u.room === room.id).map(u => u.user)


### PR DESCRIPTION
### Description
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->
This PR adds an option to have room descriptions by adding an extra `description` field on the rooms json setting.

resolves #306
### How to test?
<!--- Provide a step by step to be followed that reproduce your feature/code changes to make the review easier. -->
1. Edit the ROOMS_DATA json key
2. Pick a room of your choosing
3. Add a `"description"` field to the room object with a string value.

### Expected behavior
<!--- Provide a minimal description of what will be achieved with the PR -->
The room will now have a hoverable icon with the provided description.
![image](https://user-images.githubusercontent.com/12252332/82739397-9fda9d80-9d15-11ea-971c-fa4895bc773d.png)

The room appbar will have the same icon with the description

![image](https://user-images.githubusercontent.com/12252332/82739426-d57f8680-9d15-11ea-9a32-2f92079100e0.png)
