### PR TITLE
fix(office): add reset to the monitoring interval when creating a new…

### DIFF
--- a/frontend/src/morpheus/containers/OfficePage.js
+++ b/frontend/src/morpheus/containers/OfficePage.js
@@ -14,12 +14,16 @@ import { emitEnterInRoom, emitStartMeeting, emitLeftMeeting} from "../socket";
 import { setCurrentRoom } from "../store/actions";
 import { CurrentRoomPropType } from "../store/models";
 
+let activeMonitorInterval;
+
 const externalMeetRoomMonitoring = (externalMeetRoom) => {
-  const interval = window.setInterval(() => {
+  window.clearInterval(activeMonitorInterval);
+
+  activeMonitorInterval = window.setInterval(() => {
     if (!externalMeetRoom.closed) return;
 
     emitLeftMeeting();
-    window.clearInterval(interval);
+    window.clearInterval(activeMonitorInterval);
   }, 1000);
 };
 


### PR DESCRIPTION
### Description
fixes #338 

### How to test?
1. Find a room with an external meeting
2. Click "Enter meeting"
3. Go back to matrix and click "Enter meeting" again
4. Close the previously opened tab

### Expected behavior
The user should keep the headphone icon when closing the previously opened tab.
