### PR TITLE
#343 ignore accents in search

### DIFF
--- a/frontend/src/morpheus/store/reducers.js
+++ b/frontend/src/morpheus/store/reducers.js
@@ -56,7 +56,13 @@ export const initialState = {
   }
 };
 
+// Removes accents from a string and makes it lowercase.
 const normalize = str => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
+// Creates a filter function normalizing both the field value and query
+const normalizedFilter = (field, query) => {
+  return (item) => normalize(item[field]).includes(normalize(query));
+};
 
 const buildOfficeState = state => {
   const { rooms, usersInRoom, officeFilter } = state;
@@ -74,8 +80,8 @@ const buildOfficeState = state => {
     office = office.filter(o => o.users.length > 0);
   }
   if (officeFilter.search) {
-    const search = officeFilter.search.toLowerCase();
-    office = office.filter(room => normalize(room.name).includes(normalize(search)));
+    const { search } = officeFilter;
+    office = office.filter(normalizedFilter("name", search));
   }
 
   return {
@@ -101,8 +107,8 @@ const buildUsersState = state => {
   });
 
   if (usersFilter.search) {
-    const search = usersFilter.search.toLowerCase();
-    users = users.filter(u => normalize(u.name).includes(normalize(search)));
+    const { search } = usersFilter;
+    users = users.filter(normalizedFilter("name", search));
   }
 
   return {

--- a/frontend/src/morpheus/store/reducers.js
+++ b/frontend/src/morpheus/store/reducers.js
@@ -60,9 +60,9 @@ export const initialState = {
 const normalize = str => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
 
 // Creates a filter function normalizing both the field value and query
-const normalizedFilter = (field, query) => {
-  return (item) => normalize(item[field]).includes(normalize(query));
-};
+const normalizedFilter = (field, query) => (
+  (item) => normalize(item[field]).includes(normalize(query))
+);
 
 const buildOfficeState = state => {
   const { rooms, usersInRoom, officeFilter } = state;

--- a/frontend/src/morpheus/store/reducers.js
+++ b/frontend/src/morpheus/store/reducers.js
@@ -56,6 +56,8 @@ export const initialState = {
   }
 };
 
+const normalize = str => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
 const buildOfficeState = state => {
   const { rooms, usersInRoom, officeFilter } = state;
 
@@ -73,7 +75,7 @@ const buildOfficeState = state => {
   }
   if (officeFilter.search) {
     const search = officeFilter.search.toLowerCase();
-    office = office.filter(o => o.name.toLowerCase().includes(search));
+    office = office.filter(room => normalize(room.name).includes(normalize(search)));
   }
 
   return {
@@ -100,7 +102,7 @@ const buildUsersState = state => {
 
   if (usersFilter.search) {
     const search = usersFilter.search.toLowerCase();
-    users = users.filter(u => u.name.toLowerCase().includes(search));
+    users = users.filter(u => normalize(u.name).includes(normalize(search)));
   }
 
   return {

--- a/frontend/test/morpheus/store/reducers.test.js
+++ b/frontend/test/morpheus/store/reducers.test.js
@@ -5,6 +5,8 @@ import sinon from "sinon";
 import {
   addRooms,
   syncOffice,
+  changeOfficeFilter,
+  changeUsersFilter,
   toggleTheme
 } from "../../../src/morpheus/store/actions";
 import reducers, { initialState } from "../../../src/morpheus/store/reducers";
@@ -207,6 +209,115 @@ describe("morpheus/store/reducers", () => {
         }
       }
     });
+
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+
+    expect(reducers(stateBefore, action)).to.deep.equal(stateAfter);
+  });
+
+  it("should reduce action CHANGE_OFFICE_FILTER with accents", () => {
+    const stateBefore = {
+      ...initialState,
+      rooms: [
+        { id: "1", name: "Café", externalMeetUrl:"http://externalMeetUrl-1", users: [], disableMeeting: true },
+        { id: "2", name: "Another", externalMeetUrl:"http://externalMeetUrl-2", users: [], description: "Hello" }
+      ],
+      office: [
+        { id: "1", name: "Café", externalMeetUrl:"http://externalMeetUrl-1", users: [], disableMeeting: true },
+        { id: "2", name: "Another", externalMeetUrl:"http://externalMeetUrl-2", users: [], description: "Hello" }
+      ]
+    };
+
+    const stateAfter = {
+      ...initialState,
+      officeFilter: {
+        onlyFullRoom: false,
+        search: "cafe"
+      },
+      rooms: [
+        { id: "1", name: "Café", externalMeetUrl:"http://externalMeetUrl-1", users: [], disableMeeting: true },
+        { id: "2", name: "Another", externalMeetUrl:"http://externalMeetUrl-2", users: [], description: "Hello" },
+      ],
+      office: [
+        {
+          id: "1",
+          name: "Café",
+          externalMeetUrl:"http://externalMeetUrl-1",
+          users: [],
+          description: undefined,
+          meetingEnabled: false,
+        },
+      ]
+    };
+
+    const action = changeOfficeFilter("search", "cafe");
+
+    deepFreeze(stateBefore);
+    deepFreeze(action);
+
+    expect(reducers(stateBefore, action)).to.deep.equal(stateAfter);
+  });
+
+  it("should reduce action CHANGE_USERS_FILTER with accents", () => {
+    const users = [
+      { name: "José", room: "1" },
+      { name: "Phillip", room: "1" },
+    ];
+
+    const room = { id: "1", name: "Café", externalMeetUrl:"http://externalMeetUrl-1", users, disableMeeting: true };
+    const stateBefore = {
+      ...initialState,
+      rooms: [
+        room,
+      ],
+      office: [
+        room,
+      ],
+      usersInRoom: [
+        {
+          user: users[0],
+          room,
+        },
+        {
+          user: users[1],
+          room,
+        },
+      ],
+    };
+
+    const stateAfter = {
+      ...initialState,
+      usersFilter: {
+        search: "jose"
+      },
+      users: [{
+        avatar: undefined,
+        id: undefined,
+        inMeet: false,
+        name: "José",
+        roomId: "",
+        roomName: ""
+      }],
+      rooms: [
+        room,
+      ],
+      office: [
+        room,
+      ],
+      usersInRoom: [
+        {
+          user: users[0],
+          room,
+        },
+        {
+          user: users[1],
+          room,
+        },
+      ],
+    };
+
+    const action = changeUsersFilter("search", "jose");
 
     deepFreeze(stateBefore);
     deepFreeze(action);


### PR DESCRIPTION
### Description
Resolves #343 

### How to test?
1. Have a user or room with an accent somewhere in the name (eg: José/Café)
2. Search for their name without including an accent (jose)

### Expected behavior
User should show up even if the search query doesn't include the accent.

#### Proof:

![xxx](https://user-images.githubusercontent.com/12252332/88057574-a7150080-cb38-11ea-91cc-d393f1b18fd7.gif)
